### PR TITLE
[FIX] move get fen to the board class

### DIFF
--- a/src/algebraicGameClient.js
+++ b/src/algebraicGameClient.js
@@ -259,40 +259,6 @@ export class AlgebraicGameClient extends EventEmitter {
 		};
 	}
 
-	getFen () {
-		const fen = [];
-		const squares = this.game.board.squares
-			.reduce((acc, cur, idx) => {
-				const outerIdx = parseInt(idx / 8, 10);
-				acc[outerIdx] = acc[outerIdx] || [];
-				acc[outerIdx].push(cur);
-				return acc;
-			}, [])
-			.flatMap((row) => row.reverse())
-			.reverse();
-
-		for (let i = 0; i < squares.length; i += 1) {
-			const square = squares[i];
-
-			if (square.file === 'a' && square.rank < 8) {
-				fen.push('/');
-			}
-
-			if (square.piece) {
-				const transform = `to${square.piece.side.name === 'white' ? 'Upp' : 'Low'}erCase`;
-				fen.push((square.piece.notation || 'p')[transform]());
-			} else {
-				if (isNaN(Number(fen[fen.length - 1]))) {
-					fen.push(1);
-				} else {
-					fen[fen.length - 1] += 1;
-				}
-			}
-		}
-
-		return fen.join('');
-	}
-
 	move (notation, isFuzzy) {
 		let
 			move = null,

--- a/src/algebraicGameClient.js
+++ b/src/algebraicGameClient.js
@@ -259,6 +259,10 @@ export class AlgebraicGameClient extends EventEmitter {
 		};
 	}
 
+	getFen () {
+		return this.game.board.getFen();
+	}
+
 	move (notation, isFuzzy) {
 		let
 			move = null,

--- a/src/board.js
+++ b/src/board.js
@@ -126,6 +126,40 @@ export class Board extends EventEmitter {
 		}, []));
 	}
 
+	getFen () {
+		const fen = [];
+		const squares = this.squares
+			.reduce((acc, cur, idx) => {
+				const outerIdx = parseInt(idx / 8, 10);
+				acc[outerIdx] = acc[outerIdx] || [];
+				acc[outerIdx].push(cur);
+				return acc;
+			}, [])
+			.flatMap((row) => row.reverse())
+			.reverse();
+
+		for (let i = 0; i < squares.length; i += 1) {
+			const square = squares[i];
+
+			if (square.file === 'a' && square.rank < 8) {
+				fen.push('/');
+			}
+
+			if (square.piece) {
+				const transform = `to${square.piece.side.name === 'white' ? 'Upp' : 'Low'}erCase`;
+				fen.push((square.piece.notation || 'p')[transform]());
+			} else {
+				if (isNaN(Number(fen[fen.length - 1]))) {
+					fen.push(1);
+				} else {
+					fen[fen.length - 1] += 1;
+				}
+			}
+		}
+
+		return fen.join('');
+	}
+
 	getNeighborSquare (sq, n) {
 		if (sq && n) {
 			// validate boundaries of board


### PR DESCRIPTION
It will make `getFen()` method available for both clients. Before you can call it from the algebraic client only. Fallback added to tests passing.