### PR TITLE
Expose getFen method in types

### DIFF
--- a/@types/chess/chess.d.ts
+++ b/@types/chess/chess.d.ts
@@ -53,6 +53,7 @@ declare namespace Chess {
     /** Whether notation is safe for PGN or not */
     PGN: boolean
     getStatus(): AlgebraicGameStatus
+    getFen(): string
   }
 
   type File = string


### PR DESCRIPTION
`AlgebraicGameClient` implements a method `getFen`, but this isn't discoverable or easy to use from typescript. This method is useful for exporting the chess board state, so it can be stored compactly or passed to another library.
By adding the `getFen` method to the types, it becomes easier to use.